### PR TITLE
Update OpenSearch Serverless VPC CIDR to 10.1.0.0/16

### DIFF
--- a/examples/opensearchserverless/vpc.tf
+++ b/examples/opensearchserverless/vpc.tf
@@ -3,7 +3,7 @@
 
 # Creates a VPC
 resource "aws_vpc" "vpc" {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
 
   tags = {
@@ -14,7 +14,7 @@ resource "aws_vpc" "vpc" {
 # Creates a subnet
 resource "aws_subnet" "subnet" {
   vpc_id     = aws_vpc.vpc.id
-  cidr_block = "10.0.0.0/16"
+  cidr_block = "10.1.0.0/16"
 
   tags = {
     Name = "example-subnet"


### PR DESCRIPTION
## Summary
Updated the OpenSearch Serverless VPC configuration to use CIDR block `10.1.0.0/16` instead of `10.0.0.0/16`.

## Changes Made
- **aws_vpc.vpc**: Changed `cidr_block` from `10.0.0.0/16` to `10.1.0.0/16`
- **aws_subnet.subnet**: Changed `cidr_block` from `10.0.0.0/16` to `10.1.0.0/16`

## Terraform Plan Summary
```
Plan: 8 to add, 0 to change, 0 to destroy
```

## Infrastructure Applied
✅ **Successfully applied via Terraform**
- Created VPC with new CIDR: `vpc-05ca508da6464dc22`
- Created subnet with new CIDR: `subnet-0fe31dfe5591869b3` 
- Created Internet Gateway: `igw-0c2381a51899edc84`
- Created route table and associations
- Created security group and rules

## Testing
The infrastructure has been successfully deployed and validated in AWS eu-west-2 region.

## Files Modified
- `examples/opensearchserverless/vpc.tf`