### PR TITLE
Update OpenSearch Serverless VPC CIDR to 10.1.0.0/16

### DIFF
--- a/examples/opensearchserverless/vpc.tf
+++ b/examples/opensearchserverless/vpc.tf
@@ -3,7 +3,7 @@
 
 # Creates a VPC
 resource "aws_vpc" "vpc" {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
 
   tags = {
@@ -14,7 +14,7 @@ resource "aws_vpc" "vpc" {
 # Creates a subnet
 resource "aws_subnet" "subnet" {
   vpc_id     = aws_vpc.vpc.id
-  cidr_block = "10.0.0.0/16"
+  cidr_block = "10.1.0.0/24"
 
   tags = {
     Name = "example-subnet"


### PR DESCRIPTION
## Summary
Updated the OpenSearch Serverless VPC configuration to use CIDR block `10.1.0.0/16` instead of `10.0.0.0/16`.

## Changes Made
- **VPC CIDR**: Changed from `10.0.0.0/16` to `10.1.0.0/16`
- **Subnet CIDR**: Fixed from `10.0.0.0/16` to `10.1.0.0/24` (proper subnet sizing within VPC)

## Infrastructure Impact
✅ **Terraform Apply Completed Successfully**
- 8 resources created
- Resources: VPC, subnet, internet gateway, route table, route table association, security group, and security group rules
- No existing resources affected (this was a new deployment for testing)

## Files Changed
- `examples/opensearchserverless/vpc.tf`

## Testing
- Terraform plan executed successfully
- Terraform apply completed without errors
- All resources created in eu-west-2 region

## Additional Notes
This change also fixed an issue where the subnet was incorrectly using the same CIDR block as the VPC (`10.0.0.0/16`). The subnet now properly uses a `/24` subnet (`10.1.0.0/24`) within the VPC range.