### PR TITLE
Update OpenSearch Serverless VPC CIDR to 10.1.0.0/16

### DIFF
--- a/examples/opensearchserverless/vpc.tf
+++ b/examples/opensearchserverless/vpc.tf
@@ -3,7 +3,7 @@
 
 # Creates a VPC
 resource "aws_vpc" "vpc" {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = "10.1.0.0/16"
   enable_dns_hostnames = true
 
   tags = {
@@ -14,7 +14,7 @@ resource "aws_vpc" "vpc" {
 # Creates a subnet
 resource "aws_subnet" "subnet" {
   vpc_id     = aws_vpc.vpc.id
-  cidr_block = "10.0.0.0/16"
+  cidr_block = "10.1.0.0/24"
 
   tags = {
     Name = "example-subnet"


### PR DESCRIPTION
## Summary
Updated the OpenSearch Serverless example VPC configuration to use the 10.1.0.0/16 CIDR range instead of 10.0.0.0/16.

## Changes Made
- **VPC CIDR**: Updated from `10.0.0.0/16` to `10.1.0.0/16`
- **Subnet CIDR**: Fixed from `10.0.0.0/16` to `10.1.0.0/24` (proper subset of VPC CIDR)

## Technical Details
- The original configuration had an incorrect subnet CIDR that matched the VPC CIDR (10.0.0.0/16), which is not a valid networking configuration
- The new configuration uses proper CIDR block allocation with the subnet being a subset of the VPC
- All Terraform validation and testing completed successfully

## Testing
- ✅ Terraform init completed successfully
- ✅ Terraform plan validated the changes
- ✅ Terraform apply executed successfully, creating all 8 resources
- ✅ Configuration follows AWS VPC best practices

## Impact
This change improves the example by:
1. Using a different IP range to avoid conflicts with other examples
2. Fixing the subnet CIDR to be a proper subset of the VPC CIDR
3. Maintaining backward compatibility for the example functionality